### PR TITLE
Bug fix for null pointer in line 16 of selector.php

### DIFF
--- a/app/plugins/projects/files/views/selector/tmpl/selector.php
+++ b/app/plugins/projects/files/views/selector/tmpl/selector.php
@@ -13,7 +13,7 @@ defined('_HZEXEC_') or die();
 	<ul class="file-selector" id="file-selector">
 <?php endif; ?>
 
-<?php if (count($this->items) > 0) : ?>
+<?php if (isset($this->items) && count($this->items) > 0) : ?>
 	<?php $a = 1; ?>
 	<?php foreach ($this->items as $item)
 	{


### PR DESCRIPTION
# Before you submit this pull request, please make sure:

- [] Make sure there are links in the PR to the source JIRA card(s) and hubzero ticket(s)
- [] Include a brief summary of the issue **in your own words**
- [] Include a brief summary of the fix/changed code
- [] Include a brief summary of your testing. What did you **specifically** do to investigate that this change has the correct results?
- [] Indicate if the change needs to be hotfixed to any production hubs before a normal core rollout
- [] Double check someone is assigned to review the ticket

**Thanks!**

This request contains no tickets. It's for a null pointer fix in qubeshub\public\app\plugins\projects\files\views\selector\tmpl\selector.php line 16. File selector within resource page would not appear and show a null pointer error instead on the GUI. After testing with the fix, file selector appears again.



